### PR TITLE
Full Changelog Endpoint

### DIFF
--- a/api/changelog.go
+++ b/api/changelog.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Changelog = apitypes.Changelog
+type FullChangelog = apitypes.FullChangelog
 
 func (c *Client) GetChangelog(ctx context.Context, changelogID string) (Changelog, error) {
 	req, err := c.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/changelogs/%s", changelogID), nil)
@@ -25,6 +26,23 @@ func (c *Client) GetChangelog(ctx context.Context, changelogID string) (Changelo
 	defer resp.Body.Close()
 
 	var cl Changelog
+	err = resp.DecodeJSON(&cl)
+	return cl, err
+}
+
+func (c *Client) GetFullChangelog(ctx context.Context, changelogID string) (FullChangelog, error) {
+	req, err := c.NewRequest(ctx, http.MethodGet, fmt.Sprintf("/changelogs/%s/full", changelogID), nil)
+	if err != nil {
+		return FullChangelog{}, err
+	}
+
+	resp, err := c.rawRequestWithContext(req)
+	if err != nil {
+		return FullChangelog{}, fmt.Errorf("error while getting full changelog %s: %w", changelogID, err)
+	}
+	defer resp.Body.Close()
+
+	var cl FullChangelog
 	err = resp.DecodeJSON(&cl)
 	return cl, err
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
-	github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64
+	github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750
 	golang.org/x/net v0.25.0
 )
 

--- a/api/go.sum
+++ b/api/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
-github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64 h1:yeoqi6Ur2IdboPLZU4I5XR+VzSQVEH+EwW4kPhun/EU=
-github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64/go.mod h1:xnbFN3Wrw2B1F/D7pvjjwoeXSt+njRI31ccPFno0BM0=
+github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750 h1:BmLPTv3FxvExggIphzeuXYIhUmmhbCmCUDGqu1jX4Kw=
+github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750/go.mod h1:xnbFN3Wrw2B1F/D7pvjjwoeXSt+njRI31ccPFno0BM0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/apitypes/changelog.go
+++ b/apitypes/changelog.go
@@ -29,6 +29,20 @@ const (
 	System ColorScheme = "system"
 )
 
+type FullChangelog struct {
+	Changelog       Changelog `json:"changelog"`
+	Articles        []Article `json:"articles"`
+	HasMoreArticles bool      `json:"hasMoreArticles"`
+}
+
+type Article struct {
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	PublishedAt time.Time `json:"publishedAt"`
+	Tags        []string  `json:"tags"`
+	HTMLContent string    `json:"htmlContent"`
+}
+
 func (l Changelog) MarshalJSON() ([]byte, error) {
 	obj := struct {
 		ID            string     `json:"id"`

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -42,7 +42,7 @@ func main() {
 
 	loader := changelog.NewLoader(cfg, st, cache)
 
-	rest.RegisterRestHandler(mux, rest.NewEnv(st))
+	rest.RegisterRestHandler(mux, rest.NewEnv(st, loader))
 	web.RegisterWebHandler(mux, web.NewEnv(cfg, loader, render.New(cfg)))
 	rss.RegisterRSSHandler(mux, rss.NewEnv(cfg, loader))
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.10.0
 	github.com/google/go-github/v62 v62.0.0
 	github.com/guregu/null/v5 v5.0.0
-	github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64
+	github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750
 	github.com/mattn/go-sqlite3 v1.14.16
 	github.com/naveensrinivasan/httpcache v1.2.1
 	github.com/peterbourgon/diskv v2.0.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/guregu/null/v5 v5.0.0/go.mod h1:SjupzNy+sCPtwQTKWhUCqjhVCO69hpsl2QsZr
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64 h1:yeoqi6Ur2IdboPLZU4I5XR+VzSQVEH+EwW4kPhun/EU=
-github.com/jonashiltl/openchangelog/apitypes v0.0.0-20240920110319-6925911f7f64/go.mod h1:xnbFN3Wrw2B1F/D7pvjjwoeXSt+njRI31ccPFno0BM0=
+github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750 h1:BmLPTv3FxvExggIphzeuXYIhUmmhbCmCUDGqu1jX4Kw=
+github.com/jonashiltl/openchangelog/apitypes v0.0.0-20241013123337-70a1f28d7750/go.mod h1:xnbFN3Wrw2B1F/D7pvjjwoeXSt+njRI31ccPFno0BM0=
 github.com/kr/http v0.0.0-20150505212737-77bd98b60462 h1:b07ir+udaggBgCywmX2B8jIvNJJaEYXLjnLzIHm/uVg=
 github.com/kr/http v0.0.0-20150505212737-77bd98b60462/go.mod h1:cM5SqzKqF3qr2a/EhVFFGK1+3Co6d40ogrTacbrLzvA=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/internal/handler/rest/routes.go
+++ b/internal/handler/rest/routes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/jonashiltl/openchangelog/internal/changelog"
 	"github.com/jonashiltl/openchangelog/internal/errs"
 	"github.com/jonashiltl/openchangelog/internal/store"
 )
@@ -30,25 +31,26 @@ func RegisterRestHandler(mux *http.ServeMux, e *env) {
 	mux.HandleFunc("POST /api/changelogs", serveHTTP(e, createChangelog))
 	mux.HandleFunc("GET /api/changelogs", serveHTTP(e, listChangelogs))
 	mux.HandleFunc("GET /api/changelogs/{cid}", serveHTTP(e, getChangelog))
+	mux.HandleFunc("GET /api/changelogs/{cid}/full", serveHTTP(e, getFullChangelog))
 	mux.HandleFunc("PATCH /api/changelogs/{cid}", serveHTTP(e, updateChangelog))
 	mux.HandleFunc("DELETE /api/changelogs/{cid}", serveHTTP(e, deleteChangelog))
 	mux.HandleFunc("PUT /api/changelogs/{cid}/source/{sid}", serveHTTP(e, setChangelogSource))
 	mux.HandleFunc("DELETE /api/changelogs/{cid}/source", serveHTTP(e, deleteChangelogSource))
 }
 
-func NewEnv(store store.Store) *env {
+func NewEnv(store store.Store, loader *changelog.Loader) *env {
 	return &env{
-		store: store,
+		store:  store,
+		loader: loader,
 	}
 }
 
 type env struct {
-	store store.Store
+	store  store.Store
+	loader *changelog.Loader
 }
 
-type handler = func(e *env, w http.ResponseWriter, r *http.Request) error
-
-func serveHTTP(env *env, h handler) func(w http.ResponseWriter, r *http.Request) {
+func serveHTTP(env *env, h func(e *env, w http.ResponseWriter, r *http.Request) error) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		err := h(env, w, r)
 

--- a/internal/handler/utils.go
+++ b/internal/handler/utils.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"net/url"
+	"strconv"
 )
 
 const (
@@ -61,4 +62,18 @@ func FeedToChangelogURL(r *http.Request) string {
 	}
 
 	return newURL.String()
+}
+
+func ParsePagination(q url.Values) (page int, size int) {
+	const default_page, default_page_size = 1, 10
+	page, err := strconv.Atoi(q.Get("page"))
+	if err != nil {
+		page = default_page
+	}
+	pageSize, err := strconv.Atoi(q.Get("page-size"))
+	if err != nil {
+		pageSize = default_page_size
+	}
+
+	return page, pageSize
 }

--- a/internal/handler/utils_test.go
+++ b/internal/handler/utils_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -79,6 +80,39 @@ func TestChangelogToFeedURL(t *testing.T) {
 		changelogURL := ChangelogToFeedURL(r)
 		if changelogURL != table.expected {
 			t.Fatalf("expected %s to equal %s", changelogURL, table.expected)
+		}
+	}
+}
+
+func TestParsePagination(t *testing.T) {
+	tables := []struct {
+		page     int
+		pageSize int
+	}{
+		{
+			page:     0,
+			pageSize: 0,
+		},
+		{
+			page:     1,
+			pageSize: 1,
+		},
+		{
+			page:     10,
+			pageSize: 10,
+		},
+	}
+
+	for _, table := range tables {
+		q := url.Values{}
+		q.Set("page", fmt.Sprint(table.page))
+		q.Set("page-size", fmt.Sprint(table.pageSize))
+		p, s := ParsePagination(q)
+		if table.page != p {
+			t.Errorf("expected %d to equal %d", p, table.page)
+		}
+		if table.pageSize != s {
+			t.Errorf("expected %d to equal %d", s, table.pageSize)
 		}
 	}
 }

--- a/internal/handler/web/index.go
+++ b/internal/handler/web/index.go
@@ -2,29 +2,16 @@ package web
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/jonashiltl/openchangelog/internal/changelog"
 	"github.com/jonashiltl/openchangelog/internal/handler"
 	"github.com/jonashiltl/openchangelog/render"
 )
 
-const (
-	default_page      = 1
-	default_page_size = 10
-)
-
 func index(e *env, w http.ResponseWriter, r *http.Request) error {
-	q := r.URL.Query()
-	page, err := strconv.Atoi(q.Get("page"))
-	if err != nil {
-		page = default_page
-	}
-	pageSize, err := strconv.Atoi(q.Get("page-size"))
-	if err != nil {
-		pageSize = default_page_size
-	}
+	page, pageSize := handler.ParsePagination(r.URL.Query())
 
+	var err error
 	var l *changelog.LoadedChangelog
 	if e.cfg.IsDBMode() {
 		l, err = loadChangelogDBMode(e, r, changelog.NewPagination(pageSize, page))


### PR DESCRIPTION
Adds the `/api/changelogs/{cid}/full` endpoint to get a changelog and it's articles through the API