### PR TITLE
Keep A Changelog parser

### DIFF
--- a/.testdata/keepachangelog/full.md
+++ b/.testdata/keepachangelog/full.md
@@ -1,0 +1,263 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- v1.1 Brazilian Portuguese translation.
+- v1.1 German Translation
+- v1.1 Spanish translation.
+- v1.1 Italian translation.
+- v1.1 Polish translation.
+- v1.1 Ukrainian translation.
+
+### Changed
+
+- Use frontmatter title & description in each language version template
+- Replace broken OpenGraph image with an appropriately-sized Keep a Changelog 
+  image that will render properly (although in English for all languages)
+- Fix OpenGraph title & description for all languages so the title and 
+description when links are shared are language-appropriate
+
+### Removed
+
+- Trademark sign previously shown after the project description in version 
+0.3.0
+
+## [1.1.1] - 2023-03-05
+
+### Added
+
+- Arabic translation (#444).
+- v1.1 French translation.
+- v1.1 Dutch translation (#371).
+- v1.1 Russian translation (#410).
+- v1.1 Japanese translation (#363).
+- v1.1 Norwegian Bokmål translation (#383).
+- v1.1 "Inconsistent Changes" Turkish translation (#347).
+- Default to most recent versions available for each languages.
+- Display count of available translations (26 to date!).
+- Centralize all links into `/data/links.json` so they can be updated easily.
+
+### Fixed
+
+- Improve French translation (#377).
+- Improve id-ID translation (#416).
+- Improve Persian translation (#457).
+- Improve Russian translation (#408).
+- Improve Swedish title (#419).
+- Improve zh-CN translation (#359).
+- Improve French translation (#357).
+- Improve zh-TW translation (#360, #355).
+- Improve Spanish (es-ES) transltion (#362).
+- Foldout menu in Dutch translation (#371).
+- Missing periods at the end of each change (#451).
+- Fix missing logo in 1.1 pages.
+- Display notice when translation isn't for most recent version.
+- Various broken links, page versions, and indentations.
+
+### Changed
+
+- Upgrade dependencies: Ruby 3.2.1, Middleman, etc.
+
+### Removed
+
+- Unused normalize.css file.
+- Identical links assigned in each translation file.
+- Duplicate index file for the english version.
+
+## [1.1.0] - 2019-02-15
+
+### Added
+
+- Danish translation (#297).
+- Georgian translation from (#337).
+- Changelog inconsistency section in Bad Practices.
+
+### Fixed
+
+- Italian translation (#332).
+- Indonesian translation (#336).
+
+## [1.0.0] - 2017-06-20
+
+### Added
+
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+- Links to latest released version in previous versions.
+- "Why keep a changelog?" section.
+- "Who needs a changelog?" section.
+- "How do I make a changelog?" section.
+- "Frequently Asked Questions" section.
+- New "Guiding Principles" sub-section to "How do I make a changelog?".
+- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
+- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- Italian translation from [@azkidenz](https://github.com/azkidenz).
+- Swedish translation from [@magol](https://github.com/magol).
+- Turkish translation from [@emreerkan](https://github.com/emreerkan).
+- French translation from [@zapashcanon](https://github.com/zapashcanon).
+- Brazilian Portuguese translation from [@Webysther](https://github.com/Webysther).
+- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
+- Russian translation from [@aishek](https://github.com/aishek).
+- Czech translation from [@h4vry](https://github.com/h4vry).
+- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
+- Korean translation from [@pierceh89](https://github.com/pierceh89).
+- Croatian translation from [@porx](https://github.com/porx).
+- Persian translation from [@Hameds](https://github.com/Hameds).
+- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+
+### Changed
+
+- Start using "changelog" over "change log" since it's the common usage.
+- Start versioning based on the current English version at 0.3.0 to help
+  translation authors keep things up-to-date.
+- Rewrite "What makes unicorns cry?" section.
+- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
+  scenario.
+- Improve "Commit log diffs" sub-section to further argument against
+  them.
+- Merge "Why can’t people just use a git log diff?" with "Commit log
+  diffs".
+- Fix typos in Simplified Chinese and Traditional Chinese translations.
+- Fix typos in Brazilian Portuguese translation.
+- Fix typos in Turkish translation.
+- Fix typos in Czech translation.
+- Fix typos in Swedish translation.
+- Improve phrasing in French translation.
+- Fix phrasing and spelling in German translation.
+
+### Removed
+
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+
+### Added
+
+- RU translation from [@aishek](https://github.com/aishek).
+- pt-BR translation from [@tallesl](https://github.com/tallesl).
+- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
+
+## [0.2.0] - 2015-10-06
+
+### Changed
+
+- Remove exclusionary mentions of "open source" since this project can
+  benefit both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+
+### Added
+
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+
+- Improve argument against commit logs.
+- Start following [SemVer](https://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+
+### Changed
+
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+
+### Added
+
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+
+### Added
+
+- README section on "yanked" releases.
+
+## [0.0.5] - 2014-08-09
+
+### Added
+
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+  keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+
+### Added
+
+- Better explanation of the difference between the file ("CHANGELOG")
+  and its function "the change log".
+
+### Changed
+
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+  to differentiate between the file and the purpose of the file — the
+  logging of changes.
+
+### Removed
+
+- Remove empty sections from CHANGELOG, they occupy too much space and
+  create too much noise in the file. People will have to assume that the
+  missing sections were intentionally left out because they contained no
+  notable changes.
+
+## [0.0.3] - 2014-08-09
+
+### Added
+
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+
+### Added
+
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+
+### Added
+
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain.
+- README now contains answers to common questions about CHANGELOGs.
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?".
+
+[unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1

--- a/.testdata/keepachangelog/minimal.md
+++ b/.testdata/keepachangelog/minimal.md
@@ -1,0 +1,26 @@
+# Changelog
+Description
+
+## [1.1.1] - 2023-03-05
+
+### Added
+
+- Arabic translation (#444).
+- v1.1 French translation.
+- v1.1 Dutch translation (#371).
+
+### Fixed
+
+- Improve French translation (#377).
+- Improve id-ID translation (#416).
+- Improve Persian translation (#457).
+
+### Changed
+
+- Upgrade dependencies: Ruby 3.2.1, Middleman, etc.
+
+### Removed
+
+- Unused normalize.css file.
+- Identical links assigned in each translation file.
+- Duplicate index file for the english version.

--- a/.testdata/keepachangelog/unreleased.md
+++ b/.testdata/keepachangelog/unreleased.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- v1.1 Brazilian Portuguese translation.
+- v1.1 German Translation
+- v1.1 Spanish translation.
+- v1.1 Italian translation.
+- v1.1 Polish translation.
+- v1.1 Ukrainian translation.
+
+### Changed
+
+- Use frontmatter title & description in each language version template
+- Replace broken OpenGraph image with an appropriately-sized Keep a Changelog 
+  image that will render properly (although in English for all languages)
+- Fix OpenGraph title & description for all languages so the title and 
+description when links are shared are language-appropriate
+
+### Removed
+
+- Trademark sign previously shown after the project description in version 
+0.3.0

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@
 <br />
 </p>
 
-Openchangelog takes your Markdown files, hosted on GitHub or locally and renders them as a beautiful Changelog Website.
+Openchangelog takes your Changelog, hosted on GitHub or locally and renders it as a beautiful Changelog Website.
 - Dark, Light and System themes
 - Colorful Tags
 - Automatic RSS feed
 - Password Protection
+- Supports [keep a changelog](https://keepachangelog.com/en/1.1.0/) format or 1 Markdown file per release
 - Various integrations, open an issue to request a new integration
 
 ## Quickstart

--- a/components/article.templ
+++ b/components/article.templ
@@ -3,6 +3,7 @@ package components
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 type ArticleListArgs struct {
@@ -37,7 +38,7 @@ type ArticleArgs struct {
 	ID          string
 	Title       string
 	Description string
-	PublishedAt string
+	PublishedAt time.Time
 	Tags        []string
 	Content     string
 }
@@ -55,7 +56,9 @@ templ Article(a ArticleArgs) {
 		</h2>
 		<p class="text-caption">{ a.Description }</p>
 		<div class="lg:absolute lg:-left-40 lg:max-w-40 lg:top-0 lg:mt-1 lg:mr-2 flex flex-row gap-2 lg:gap-0 items-center lg:items-start lg:flex-col">
-			<p class="text-caption text-nowrap">{ a.PublishedAt }</p>
+			if !a.PublishedAt.IsZero() {
+				<p class="text-caption text-nowrap">{ a.PublishedAt.Format("02 Jan 2006") }</p>
+			}
 			<div class="flex flex-wrap gap-2">
 				<style>
 					#tag:where([color-scheme=dark] *) {

--- a/components/article_templ.go
+++ b/components/article_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	"fmt"
 	"math"
+	"time"
 )
 
 type ArticleListArgs struct {
@@ -50,7 +51,7 @@ func ArticleList(a ArticleListArgs) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(a.NextPageURL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 21, Col: 25}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 22, Col: 25}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -69,7 +70,7 @@ type ArticleArgs struct {
 	ID          string
 	Title       string
 	Description string
-	PublishedAt string
+	PublishedAt time.Time
 	Tags        []string
 	Content     string
 }
@@ -99,7 +100,7 @@ func Article(a ArticleArgs) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(a.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 47, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 48, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -112,7 +113,7 @@ func Article(a ArticleArgs) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(a.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 48, Col: 12}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 49, Col: 12}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -134,26 +135,36 @@ func Article(a ArticleArgs) templ.Component {
 		var templ_7745c5c3_Var7 string
 		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(a.Description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 56, Col: 41}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 57, Col: 41}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><div class=\"lg:absolute lg:-left-40 lg:max-w-40 lg:top-0 lg:mt-1 lg:mr-2 flex flex-row gap-2 lg:gap-0 items-center lg:items-start lg:flex-col\"><p class=\"text-caption text-nowrap\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><div class=\"lg:absolute lg:-left-40 lg:max-w-40 lg:top-0 lg:mt-1 lg:mr-2 flex flex-row gap-2 lg:gap-0 items-center lg:items-start lg:flex-col\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(a.PublishedAt)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 58, Col: 54}
+		if !a.PublishedAt.IsZero() {
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<p class=\"text-caption text-nowrap\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(a.PublishedAt.Format("02 Jan 2006"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 60, Col: 77}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("</p><div class=\"flex flex-wrap gap-2\"><style>\n\t\t\t\t\t#tag:where([color-scheme=dark] *) {\n\t\t\t\t\t\tcolor: var(--tag-text-light);\n\t\t\t\t\t}\n\t\t\t\t</style>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"flex flex-wrap gap-2\"><style>\n\t\t\t\t\t#tag:where([color-scheme=dark] *) {\n\t\t\t\t\t\tcolor: var(--tag-text-light);\n\t\t\t\t\t}\n\t\t\t\t</style>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -222,7 +233,7 @@ func Tag(name string) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 75, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 78, Col: 98}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -13,18 +13,16 @@ import (
 // Groups multiple ways of loading a changelog. Either from the config, by it's subdomain or workspace.
 // After loading the changelog it can easily be parsed.
 type Loader struct {
-	cfg    config.Config
-	store  store.Store
-	cache  httpcache.Cache
-	parser Parser
+	cfg   config.Config
+	store store.Store
+	cache httpcache.Cache
 }
 
 func NewLoader(cfg config.Config, store store.Store, cache httpcache.Cache) *Loader {
 	return &Loader{
-		cfg:    cfg,
-		store:  store,
-		cache:  cache,
-		parser: NewOGParser(),
+		cfg:   cfg,
+		store: store,
+		cache: cache,
 	}
 }
 
@@ -41,9 +39,8 @@ func (l *Loader) FromConfig(ctx context.Context, page Pagination) (*LoadedChange
 	}
 
 	return &LoadedChangelog{
-		cl:     cl,
-		res:    res,
-		parser: l.parser,
+		cl:  cl,
+		res: res,
 	}, nil
 }
 
@@ -66,9 +63,8 @@ func (l *Loader) FromHost(ctx context.Context, host string, page Pagination) (*L
 	}
 
 	return &LoadedChangelog{
-		cl:     cl,
-		res:    res,
-		parser: l.parser,
+		cl:  cl,
+		res: res,
 	}, nil
 }
 
@@ -93,9 +89,8 @@ func (l *Loader) FromWorkspace(ctx context.Context, wID, cID string, page Pagina
 	}
 
 	return &LoadedChangelog{
-		cl:     cl,
-		res:    res,
-		parser: l.parser,
+		cl:  cl,
+		res: res,
 	}, nil
 }
 
@@ -122,9 +117,8 @@ func (l *Loader) load(ctx context.Context, cl store.Changelog, page Pagination) 
 }
 
 type LoadedChangelog struct {
-	cl     store.Changelog
-	res    LoadResult
-	parser Parser
+	cl  store.Changelog
+	res LoadResult
 }
 
 type ParsedChangelog struct {
@@ -134,7 +128,14 @@ type ParsedChangelog struct {
 }
 
 func (c *LoadedChangelog) Parse(ctx context.Context) (ParsedChangelog, error) {
-	parsed, err := c.parser.Parse(ctx, c.res.Articles)
+	var parser Parser
+	if len(c.res.Articles) == 1 {
+		parser = NewKeepAChangelogParser()
+	} else {
+		parser = NewOGParser()
+	}
+
+	parsed, err := parser.Parse(ctx, c.res.Articles)
 	if err != nil {
 		return ParsedChangelog{}, err
 	}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -135,13 +135,18 @@ var ogParser = NewOGParser()
 var kParser = NewKeepAChangelogParser()
 
 func (c *LoadedChangelog) Parse(ctx context.Context) (ParsedChangelog, error) {
-	var parsed []ParsedArticle
-	var err error
+	// TODO: better way would be to detect the correct parser based on the file content,
+	// but for now let's just have this convention.
 	if len(c.res.Articles) == 1 {
-		parsed, err = kParser.Parse(ctx, c.res.Articles[0], c.page)
-	} else {
-		parsed, err = ogParser.Parse(ctx, c.res.Articles)
+		parsed, hasMore := kParser.Parse(ctx, c.res.Articles[0], c.page)
+		return ParsedChangelog{
+			CL:       c.cl,
+			Articles: parsed,
+			HasMore:  hasMore,
+		}, nil
 	}
+
+	parsed, err := ogParser.Parse(ctx, c.res.Articles)
 	if err != nil {
 		return ParsedChangelog{}, err
 	}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -24,7 +24,7 @@ func NewLoader(cfg config.Config, store store.Store, cache httpcache.Cache) *Loa
 		cfg:    cfg,
 		store:  store,
 		cache:  cache,
-		parser: NewParser(),
+		parser: NewOGParser(),
 	}
 }
 

--- a/internal/changelog/github.go
+++ b/internal/changelog/github.go
@@ -2,7 +2,6 @@ package changelog
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,11 +28,7 @@ type ghSource struct {
 func newGHSourceFromStore(cfg config.Config, gh store.GHSource, cache httpcache.Cache) (Source, error) {
 	tr := http.DefaultTransport
 
-	if !cfg.HasGithubAuth() {
-		return nil, errors.New("missing github auth in config")
-	}
-
-	if cfg.Github.Auth.AppPrivateKey != "" && gh.InstallationID != 0 {
+	if cfg.HasGithubAuth() && cfg.Github.Auth.AppPrivateKey != "" && gh.InstallationID != 0 {
 		// Wrap the shared transport for use with the app ID 1 authenticating with installation ID 99.
 		itr, err := ghinstallation.NewKeyFromFile(tr, cfg.Github.Auth.AppID, gh.InstallationID, cfg.Github.Auth.AppPrivateKey)
 		if err != nil {
@@ -49,7 +44,7 @@ func newGHSourceFromStore(cfg config.Config, gh store.GHSource, cache httpcache.
 	}
 
 	client := github.NewClient(&http.Client{Transport: tr})
-	if cfg.Github.Auth.AccessToken != "" {
+	if cfg.HasGithubAuth() && cfg.Github.Auth.AccessToken != "" {
 		client = client.WithAuthToken(cfg.Github.Auth.AccessToken)
 	}
 

--- a/internal/changelog/keepachangelog.go
+++ b/internal/changelog/keepachangelog.go
@@ -1,0 +1,124 @@
+package changelog
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/yuin/goldmark"
+)
+
+// A parser that parses changelogs using the https://keepachangelog.com/en/1.1.0/ format.
+type keepachangelog struct {
+	gm goldmark.Markdown
+}
+
+func NewKeepAChangelogParser() Parser {
+	return &keepachangelog{
+		gm: createGoldmark(),
+	}
+}
+
+func (g *keepachangelog) Parse(ctx context.Context, raw []RawArticle) ([]ParsedArticle, error) {
+	// optimize for this, since it's the most common case. Just asingle CHANGELOG.md file.
+	if len(raw) == 1 {
+		parsed, err := g.parseChangelog(raw[0])
+		if err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	}
+
+	return nil, errors.New("keep a changelog format expects one raw article")
+}
+
+// 1. Split by ##
+//  1. section is ignored
+//  1. section is an optional unreleased section
+//     ... each section is it's own article
+func (g *keepachangelog) parseChangelog(raw RawArticle) ([]ParsedArticle, error) {
+	sc := bufio.NewScanner(raw.Content)
+
+	var articles []ParsedArticle
+	// required since g.parseArticle() returns the first line of the next article
+	var line string
+
+	// scans line per line
+	for sc.Scan() || line != "" {
+		if line == "" {
+			line = sc.Text()
+		}
+
+		if strings.HasPrefix(line, "## ") {
+			a, nextLine, err := g.parseArticle(sc)
+			if err == nil {
+				articles = append(articles, a)
+			}
+			line = nextLine
+		} else {
+			line = ""
+		}
+	}
+
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return articles, nil
+}
+
+// Called on each new ## section of the changelog file.
+// Returns the currently parsed article and the new line of the next article if another article exists.
+func (g *keepachangelog) parseArticle(sc *bufio.Scanner) (ParsedArticle, string, error) {
+	h2Parts := strings.SplitN(strings.TrimPrefix(sc.Text(), "## "), " - ", 2)
+
+	b := new(bytes.Buffer)
+	a := ParsedArticle{
+		Meta: Meta{
+			Title: cleanTitle(h2Parts[0]),
+		},
+		Content: b,
+	}
+
+	if len(h2Parts) > 1 {
+		publishedAt, err := time.Parse("2006-01-02", strings.TrimSpace(h2Parts[1]))
+		if err == nil {
+			a.Meta.PublishedAt = publishedAt
+		}
+	}
+
+	for sc.Scan() {
+		line := sc.Text()
+
+		if strings.HasPrefix(line, "## ") {
+			// begin of new article
+			return a, line, nil
+		} else if strings.HasPrefix(line, "### ") {
+			// type of change
+			parts := strings.Split(line, " ")
+			if len(parts) > 1 {
+				a.AddTag(parts[1])
+			}
+
+			b.WriteString(line + "\n")
+		} else {
+			// content line
+			b.WriteString(line + "\n")
+		}
+	}
+
+	if err := sc.Err(); err != nil {
+		return ParsedArticle{}, "", err
+	}
+
+	return a, "", nil
+}
+
+func cleanTitle(title string) string {
+	title = strings.TrimSpace(title)
+	title = strings.Replace(title, "[", "", 1)
+	return strings.Replace(title, "]", "", 1)
+}

--- a/internal/changelog/keepachangelog.go
+++ b/internal/changelog/keepachangelog.go
@@ -34,6 +34,7 @@ func (g *kparser) Parse(ctx context.Context, raw RawArticle, page Pagination) ([
 }
 
 // Returns the parsed articles and true if there are more articles to parse, else false.
+// Skips the raw article if it couldn't get parsed.
 func (g *kparser) parseChangelog(raw RawArticle, page Pagination) ([]ParsedArticle, bool) {
 	sc := bufio.NewScanner(raw.Content)
 	sc.Split(splitNewRelease)

--- a/internal/changelog/keepachangelog_test.go
+++ b/internal/changelog/keepachangelog_test.go
@@ -1,0 +1,177 @@
+package changelog
+
+import (
+	"context"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestKParseMinimal(t *testing.T) {
+	ctx := context.Background()
+	p := NewKeepAChangelogParser()
+
+	file, err := os.Open("../../.testdata/keepachangelog/minimal.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := p.Parse(ctx, []RawArticle{
+		{
+			Content: file,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(parsed) != 1 {
+		t.Fatalf("Expected 1 parsed article but got %d", len(parsed))
+	}
+
+	article := parsed[0]
+
+	expectedTags := []string{"Added", "Fixed", "Changed", "Removed"}
+	if !reflect.DeepEqual(article.Meta.Tags, expectedTags) {
+		t.Errorf("Expected %s to equal %s", article.Meta.Title, expectedTags)
+	}
+
+	expectedTitle := "1.1.1"
+	if article.Meta.Title != expectedTitle {
+		t.Errorf("Expected %s to equal %s", article.Meta.Title, expectedTitle)
+	}
+
+	expectedPublishedAt := time.Date(2023, 3, 5, 0, 0, 0, 0, time.UTC)
+	if article.Meta.PublishedAt != expectedPublishedAt {
+		t.Errorf("Expected %s to equal %s", article.Meta.PublishedAt, expectedPublishedAt)
+	}
+
+	expectedContent := `
+### Added
+
+- Arabic translation (#444).
+- v1.1 French translation.
+- v1.1 Dutch translation (#371).
+
+### Fixed
+
+- Improve French translation (#377).
+- Improve id-ID translation (#416).
+- Improve Persian translation (#457).
+
+### Changed
+
+- Upgrade dependencies: Ruby 3.2.1, Middleman, etc.
+
+### Removed
+
+- Unused normalize.css file.
+- Identical links assigned in each translation file.
+- Duplicate index file for the english version.
+`
+	all, err := io.ReadAll(article.Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(all)
+	if expectedContent != content {
+		t.Errorf("Expected \n%s to equal \n%s", content, expectedContent)
+	}
+}
+
+func TestKParseUnreleased(t *testing.T) {
+	ctx := context.Background()
+	p := NewKeepAChangelogParser()
+
+	file, err := os.Open("../../.testdata/keepachangelog/unreleased.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := p.Parse(ctx, []RawArticle{
+		{
+			Content: file,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(parsed) != 1 {
+		t.Fatalf("Expected 1 parsed article but got %d", len(parsed))
+	}
+
+	article := parsed[0]
+
+	expectedTags := []string{"Added", "Changed", "Removed"}
+	if !reflect.DeepEqual(article.Meta.Tags, expectedTags) {
+		t.Errorf("Expected %s to equal %s", article.Meta.Title, expectedTags)
+	}
+
+	expectedTitle := "Unreleased"
+	if article.Meta.Title != expectedTitle {
+		t.Errorf("Expected %s to equal %s", article.Meta.Title, expectedTitle)
+	}
+
+	expectedPublishedAt := time.Time{}
+	if article.Meta.PublishedAt != expectedPublishedAt {
+		t.Errorf("Expected %s to equal %s", article.Meta.PublishedAt, expectedPublishedAt)
+	}
+
+	expectedContent := `
+### Added
+
+- v1.1 Brazilian Portuguese translation.
+- v1.1 German Translation
+- v1.1 Spanish translation.
+- v1.1 Italian translation.
+- v1.1 Polish translation.
+- v1.1 Ukrainian translation.
+
+### Changed
+
+- Use frontmatter title & description in each language version template
+- Replace broken OpenGraph image with an appropriately-sized Keep a Changelog 
+  image that will render properly (although in English for all languages)
+- Fix OpenGraph title & description for all languages so the title and 
+description when links are shared are language-appropriate
+
+### Removed
+
+- Trademark sign previously shown after the project description in version 
+0.3.0
+`
+	all, err := io.ReadAll(article.Content)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(all)
+	if expectedContent != content {
+		t.Errorf("Expected \n%s to equal \n%s", content, expectedContent)
+	}
+}
+
+func TestKParseFull(t *testing.T) {
+	ctx := context.Background()
+	p := NewKeepAChangelogParser()
+
+	file, err := os.Open("../../.testdata/keepachangelog/full.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := p.Parse(ctx, []RawArticle{
+		{
+			Content: file,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(parsed) != 15 {
+		t.Fatalf("Expected 15 parsed article but got %d", len(parsed))
+	}
+}

--- a/internal/changelog/keepachangelog_test.go
+++ b/internal/changelog/keepachangelog_test.go
@@ -2,7 +2,6 @@ package changelog
 
 import (
 	"context"
-	"io"
 	"os"
 	"reflect"
 	"testing"
@@ -47,38 +46,6 @@ func TestKParseMinimal(t *testing.T) {
 	if article.Meta.PublishedAt != expectedPublishedAt {
 		t.Errorf("Expected %s to equal %s", article.Meta.PublishedAt, expectedPublishedAt)
 	}
-
-	expectedContent := `
-### Added
-
-- Arabic translation (#444).
-- v1.1 French translation.
-- v1.1 Dutch translation (#371).
-
-### Fixed
-
-- Improve French translation (#377).
-- Improve id-ID translation (#416).
-- Improve Persian translation (#457).
-
-### Changed
-
-- Upgrade dependencies: Ruby 3.2.1, Middleman, etc.
-
-### Removed
-
-- Unused normalize.css file.
-- Identical links assigned in each translation file.
-- Duplicate index file for the english version.
-`
-	all, err := io.ReadAll(article.Content)
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := string(all)
-	if expectedContent != content {
-		t.Errorf("Expected \n%s to equal \n%s", content, expectedContent)
-	}
 }
 
 func TestKParseUnreleased(t *testing.T) {
@@ -115,41 +82,9 @@ func TestKParseUnreleased(t *testing.T) {
 		t.Errorf("Expected %s to equal %s", article.Meta.Title, expectedTitle)
 	}
 
-	expectedPublishedAt := time.Time{}
-	if article.Meta.PublishedAt != expectedPublishedAt {
-		t.Errorf("Expected %s to equal %s", article.Meta.PublishedAt, expectedPublishedAt)
-	}
-
-	expectedContent := `
-### Added
-
-- v1.1 Brazilian Portuguese translation.
-- v1.1 German Translation
-- v1.1 Spanish translation.
-- v1.1 Italian translation.
-- v1.1 Polish translation.
-- v1.1 Ukrainian translation.
-
-### Changed
-
-- Use frontmatter title & description in each language version template
-- Replace broken OpenGraph image with an appropriately-sized Keep a Changelog 
-  image that will render properly (although in English for all languages)
-- Fix OpenGraph title & description for all languages so the title and 
-description when links are shared are language-appropriate
-
-### Removed
-
-- Trademark sign previously shown after the project description in version 
-0.3.0
-`
-	all, err := io.ReadAll(article.Content)
-	if err != nil {
-		t.Fatal(err)
-	}
-	content := string(all)
-	if expectedContent != content {
-		t.Errorf("Expected \n%s to equal \n%s", content, expectedContent)
+	expectedID := "unreleased"
+	if article.Meta.ID != expectedID {
+		t.Errorf("Expected %s to equal %s", article.Meta.ID, expectedID)
 	}
 }
 
@@ -172,6 +107,6 @@ func TestKParseFull(t *testing.T) {
 	}
 
 	if len(parsed) != 15 {
-		t.Fatalf("Expected 15 parsed article but got %d", len(parsed))
+		t.Errorf("Expected 15 parsed article but got %d", len(parsed))
 	}
 }

--- a/internal/changelog/parser.go
+++ b/internal/changelog/parser.go
@@ -20,6 +20,10 @@ type ParsedArticle struct {
 	Content io.Reader
 }
 
+func (a *ParsedArticle) AddTag(t string) {
+	a.Meta.Tags = append(a.Meta.Tags, t)
+}
+
 type Parser interface {
 	Parse(ctx context.Context, raw []RawArticle) ([]ParsedArticle, error)
 }

--- a/internal/changelog/parser.go
+++ b/internal/changelog/parser.go
@@ -3,6 +3,7 @@ package changelog
 import (
 	"context"
 	"io"
+	"slices"
 	"time"
 )
 
@@ -21,7 +22,9 @@ type ParsedArticle struct {
 }
 
 func (a *ParsedArticle) AddTag(t string) {
-	a.Meta.Tags = append(a.Meta.Tags, t)
+	if !slices.Contains(a.Meta.Tags, t) {
+		a.Meta.Tags = append(a.Meta.Tags, t)
+	}
 }
 
 type Parser interface {

--- a/render/renderer.go
+++ b/render/renderer.go
@@ -123,7 +123,7 @@ func parsedArticlesToComponentArticles(parsed []changelog.ParsedArticle) []compo
 			ID:          a.Meta.ID,
 			Title:       a.Meta.Title,
 			Description: a.Meta.Description,
-			PublishedAt: a.Meta.PublishedAt.Format("02 Jan 2006"),
+			PublishedAt: a.Meta.PublishedAt,
 			Tags:        a.Meta.Tags,
 			Content:     buf.String(),
 		}


### PR DESCRIPTION
Adds the ability to render changelogs using the [keepachangelog format](https://keepachangelog.com/en/1.1.0/).