### PR TITLE
Detect file format

### DIFF
--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -131,7 +131,7 @@ type ParsedChangelog struct {
 	HasMore  bool
 }
 
-var p = NewParser()
+var p = NewParser(createGoldmark())
 
 func (c *LoadedChangelog) Parse(ctx context.Context) ParsedChangelog {
 	parsed := p.Parse(ctx, c.res.Articles, c.page)

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -131,29 +131,15 @@ type ParsedChangelog struct {
 	HasMore  bool
 }
 
-var ogParser = NewOGParser()
-var kParser = NewKeepAChangelogParser()
+var p = NewParser()
 
-func (c *LoadedChangelog) Parse(ctx context.Context) (ParsedChangelog, error) {
-	// TODO: better way would be to detect the correct parser based on the file content,
-	// but for now let's just have this convention.
-	if len(c.res.Articles) == 1 {
-		parsed, hasMore := kParser.Parse(ctx, c.res.Articles[0], c.page)
-		return ParsedChangelog{
-			CL:       c.cl,
-			Articles: parsed,
-			HasMore:  hasMore,
-		}, nil
-	}
-
-	parsed, err := ogParser.Parse(ctx, c.res.Articles)
-	if err != nil {
-		return ParsedChangelog{}, err
-	}
+func (c *LoadedChangelog) Parse(ctx context.Context) ParsedChangelog {
+	parsed := p.Parse(ctx, c.res.Articles, c.page)
 
 	return ParsedChangelog{
 		CL:       c.cl,
-		Articles: parsed,
-		HasMore:  c.res.HasMore,
-	}, nil
+		Articles: parsed.Articles,
+		// parsed.HasMore might be true if keep-a-changelog parser finds more releases
+		HasMore: c.res.HasMore || parsed.HasMore,
+	}
 }

--- a/internal/changelog/keepachangelog.go
+++ b/internal/changelog/keepachangelog.go
@@ -15,9 +15,9 @@ type kparser struct {
 	gm goldmark.Markdown
 }
 
-func newKeepAChangelogParser() *kparser {
+func NewKeepAChangelogParser(gm goldmark.Markdown) *kparser {
 	return &kparser{
-		gm: createGoldmark(),
+		gm: gm,
 	}
 }
 

--- a/internal/changelog/keepachangelog_test.go
+++ b/internal/changelog/keepachangelog_test.go
@@ -26,7 +26,7 @@ func openKTestDataAndDetect(name string) (*os.File, string, error) {
 }
 
 func TestKParseMinimal(t *testing.T) {
-	p := newKeepAChangelogParser()
+	p := NewKeepAChangelogParser(createGoldmark())
 	file, read, err := openKTestDataAndDetect("minimal")
 	if err != nil {
 		t.Fatal(err)
@@ -60,7 +60,7 @@ func TestKParseMinimal(t *testing.T) {
 }
 
 func TestKParseUnreleased(t *testing.T) {
-	p := newKeepAChangelogParser()
+	p := NewKeepAChangelogParser(createGoldmark())
 	file, read, err := openKTestDataAndDetect("unreleased")
 	if err != nil {
 		t.Fatal(err)
@@ -94,7 +94,7 @@ func TestKParseUnreleased(t *testing.T) {
 }
 
 func TestKParseFull(t *testing.T) {
-	p := newKeepAChangelogParser()
+	p := NewKeepAChangelogParser(createGoldmark())
 	file, read, err := openKTestDataAndDetect("full")
 	if err != nil {
 		t.Fatal(err)
@@ -111,7 +111,7 @@ func TestKParseFull(t *testing.T) {
 }
 
 func TestKParsePagination(t *testing.T) {
-	p := newKeepAChangelogParser()
+	p := NewKeepAChangelogParser(createGoldmark())
 
 	tables := []struct {
 		size            int

--- a/internal/changelog/og.go
+++ b/internal/changelog/og.go
@@ -43,9 +43,9 @@ func createGoldmark() goldmark.Markdown {
 	)
 }
 
-func newOGParser() *ogparser {
+func NewOGParser(gm goldmark.Markdown) *ogparser {
 	return &ogparser{
-		gm: createGoldmark(),
+		gm: gm,
 	}
 }
 

--- a/internal/changelog/og.go
+++ b/internal/changelog/og.go
@@ -8,7 +8,7 @@ import (
 	enclave "github.com/quail-ink/goldmark-enclave"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
-	"github.com/yuin/goldmark/parser"
+	gmparser "github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
 	"go.abhg.dev/goldmark/frontmatter"
 	"mvdan.cc/xurls/v2"
@@ -75,10 +75,10 @@ func (g *ogparser) parseArticleRead(read string, rest io.ReadCloser) (ParsedArti
 
 // Don't use diretly, use parseArticle() and parseArticleRead() instead.
 func (g *ogparser) parseArticleBytes(content []byte) (ParsedArticle, error) {
-	ctx := parser.NewContext()
+	ctx := gmparser.NewContext()
 
 	var target bytes.Buffer
-	err := g.gm.Convert(content, &target, parser.WithContext(ctx))
+	err := g.gm.Convert(content, &target, gmparser.WithContext(ctx))
 	if err != nil {
 		return ParsedArticle{}, err
 	}

--- a/internal/changelog/og.go
+++ b/internal/changelog/og.go
@@ -2,11 +2,8 @@ package changelog
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
-	"sort"
-	"sync"
 
 	enclave "github.com/quail-ink/goldmark-enclave"
 	"github.com/yuin/goldmark"
@@ -19,7 +16,7 @@ import (
 
 // This is the original parser that expects one markdown file per release note.
 // All the meta information should be defined with Frontmatter.
-type og struct {
+type ogparser struct {
 	gm goldmark.Markdown
 }
 
@@ -46,50 +43,42 @@ func createGoldmark() goldmark.Markdown {
 	)
 }
 
-func NewOGParser() Parser {
-	return &og{
+func newOGParser() *ogparser {
+	return &ogparser{
 		gm: createGoldmark(),
 	}
 }
 
-func (g *og) Parse(ctx context.Context, raw []RawArticle) ([]ParsedArticle, error) {
-	var wg sync.WaitGroup
-	result := make([]ParsedArticle, 0, len(raw))
-	mutex := &sync.Mutex{}
-
-	for _, a := range raw {
-		wg.Add(1)
-		go func(a RawArticle) {
-			defer wg.Done()
-			parsed, err := g.parseArticle(a)
-			if err != nil {
-				return
-			}
-			mutex.Lock()
-			result = append(result, parsed)
-			mutex.Unlock()
-		}(a)
-	}
-	wg.Wait()
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].Meta.PublishedAt.After(result[j].Meta.PublishedAt)
-	})
-
-	return result, nil
-}
-
-func (g *og) parseArticle(raw RawArticle) (ParsedArticle, error) {
-	ctx := parser.NewContext()
-
-	defer raw.Content.Close()
-	source, err := io.ReadAll(raw.Content)
+// Takes a raw article in our original markdown format and parses it.
+func (g *ogparser) parseArticle(article io.ReadCloser) (ParsedArticle, error) {
+	defer article.Close()
+	source, err := io.ReadAll(article)
 	if err != nil {
 		return ParsedArticle{}, err
 	}
 
+	return g.parseArticleBytes(source)
+}
+
+// Parses the raw article content, but expects a part of the content to be already read (to detect the file format).
+func (g *ogparser) parseArticleRead(read string, rest io.ReadCloser) (ParsedArticle, error) {
+	defer rest.Close()
+	source, err := io.ReadAll(rest)
+	if err != nil {
+		return ParsedArticle{}, err
+	}
+
+	full := append([]byte(read), source...)
+
+	return g.parseArticleBytes(full)
+}
+
+// Don't use diretly, use parseArticle() and parseArticleRead() instead.
+func (g *ogparser) parseArticleBytes(content []byte) (ParsedArticle, error) {
+	ctx := parser.NewContext()
+
 	var target bytes.Buffer
-	err = g.gm.Convert(source, &target, parser.WithContext(ctx))
+	err := g.gm.Convert(content, &target, parser.WithContext(ctx))
 	if err != nil {
 		return ParsedArticle{}, err
 	}

--- a/internal/changelog/og_test.go
+++ b/internal/changelog/og_test.go
@@ -17,7 +17,7 @@ func openOGTestData(name string) (*os.File, error) {
 }
 
 func TestOGParseArticle(t *testing.T) {
-	p := newOGParser()
+	p := NewOGParser(createGoldmark())
 	file, err := openOGTestData("v0.0.1-commonmark")
 	if err != nil {
 		t.Fatal(err)
@@ -45,7 +45,7 @@ func TestOGParseArticle(t *testing.T) {
 }
 
 func TestOGParseArticleRead(t *testing.T) {
-	p := newOGParser()
+	p := NewOGParser(createGoldmark())
 	file, err := openOGTestData("v0.0.5-beta")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/changelog/og_test.go
+++ b/internal/changelog/og_test.go
@@ -1,0 +1,73 @@
+package changelog
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func openOGTestData(name string) (*os.File, error) {
+	file, err := os.Open(fmt.Sprintf("../../.testdata/%s.md", name))
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func TestOGParseArticle(t *testing.T) {
+	p := newOGParser()
+	file, err := openOGTestData("v0.0.1-commonmark")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parsed, err := p.parseArticle(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTags := []string{"Improvement"}
+	if !reflect.DeepEqual(parsed.Meta.Tags, expectedTags) {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.Tags, expectedTags)
+	}
+
+	expectedTitle := "CommonMark 0.31.2 compliance"
+	if parsed.Meta.Title != expectedTitle {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.Title, expectedTitle)
+	}
+
+	expectedPublishedAt := time.Date(2024, 4, 3, 0, 0, 0, 0, time.UTC)
+	if parsed.Meta.PublishedAt != expectedPublishedAt {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.PublishedAt, expectedPublishedAt)
+	}
+}
+
+func TestOGParseArticleRead(t *testing.T) {
+	p := newOGParser()
+	file, err := openOGTestData("v0.0.5-beta")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, read := detectFileFormat(file)
+	parsed, err := p.parseArticleRead(read, file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedTags := []string{"Community", "Cloud"}
+	if !reflect.DeepEqual(parsed.Meta.Tags, expectedTags) {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.Tags, expectedTags)
+	}
+
+	expectedTitle := "Open Beta"
+	if parsed.Meta.Title != expectedTitle {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.Title, expectedTitle)
+	}
+
+	expectedPublishedAt := time.Date(2024, 8, 26, 0, 0, 0, 0, time.UTC)
+	if parsed.Meta.PublishedAt != expectedPublishedAt {
+		t.Errorf("Expected %s to equal %s", parsed.Meta.PublishedAt, expectedPublishedAt)
+	}
+}

--- a/internal/changelog/parser.go
+++ b/internal/changelog/parser.go
@@ -50,7 +50,7 @@ type Parser struct {
 
 // Parses all the raw articles, uses either the keep-a-changelog parser or our og parser.
 // Uses the keep-a-changelog parser if only a single article in the keep-a-changelog format is provided.
-// Pagination is only applied when using the keep-a-changelog parser
+// Pagination is only applied when using the keep-a-changelog parser.
 // Else parses using the original parser.
 func (p *Parser) Parse(ctx context.Context, raw []RawArticle, kPage Pagination) ParseResult {
 

--- a/internal/changelog/parser.go
+++ b/internal/changelog/parser.go
@@ -1,9 +1,11 @@
 package changelog
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"slices"
+	"sync"
 	"time"
 )
 
@@ -27,6 +29,113 @@ func (a *ParsedArticle) AddTag(t string) {
 	}
 }
 
-type Parser interface {
-	Parse(ctx context.Context, raw []RawArticle) ([]ParsedArticle, error)
+type ParseResult struct {
+	Articles []ParsedArticle
+	HasMore  bool
+}
+
+func NewParser() Parser {
+	return Parser{
+		og: newOGParser(),
+		k:  newKeepAChangelogParser(),
+	}
+}
+
+type Parser struct {
+	og *ogparser
+	k  *kparser
+}
+
+// Parses all the raw articles, uses either the keep-a-changelog parser or our og parser.
+// Uses the keep-a-changelog parser if only a single article in the keep-a-changelog format is provided.
+// Pagination is only applied when using the keep-a-changelog parser
+// Else parses using the original parser.
+func (p *Parser) Parse(ctx context.Context, raw []RawArticle, kPage Pagination) ParseResult {
+
+	// sanitize pagination
+	if kPage.IsDefined() && kPage.PageSize() < 1 {
+		return ParseResult{
+			Articles: []ParsedArticle{},
+			HasMore:  false,
+		}
+	}
+
+	if len(raw) == 1 {
+		format, read := detectFileFormat(raw[0].Content)
+		if format == KeepAChangelog {
+			return p.k.parse(read, raw[0].Content, kPage)
+		}
+		parsed, err := p.og.parseArticleRead(read, raw[0].Content)
+		if err != nil {
+			return ParseResult{}
+		}
+		return ParseResult{
+			Articles: []ParsedArticle{parsed},
+			HasMore:  false, // hasMore can only be true with the keep-a-changelog parser
+		}
+	}
+
+	result := ParseResult{}
+	var wg sync.WaitGroup
+	mutex := &sync.Mutex{}
+	for _, a := range raw {
+		wg.Add(1)
+		go func(a RawArticle) {
+			defer wg.Done()
+			parsed, err := p.og.parseArticle(a.Content)
+			if err != nil {
+				return
+			}
+			mutex.Lock()
+			result.Articles = append(result.Articles, parsed)
+			mutex.Unlock()
+		}(a)
+	}
+	wg.Wait()
+
+	slices.SortFunc(result.Articles, sortArticleDesc)
+
+	return result
+}
+
+type FileFormat int
+
+const (
+	OG FileFormat = iota
+	KeepAChangelog
+)
+
+// Detects the file format of r and returns the string read to detect the file format.
+// The read string can not be read again from r.
+func detectFileFormat(r io.Reader) (FileFormat, string) {
+	var buf bytes.Buffer
+	_, err := io.CopyN(&buf, r, 3)
+	if err != nil {
+		return OG, ""
+	}
+	start := buf.String()
+	if start == "---" {
+		// if content has frontmatter => it's probably our own file format
+		return OG, start
+	}
+	return KeepAChangelog, start
+}
+
+// Sorts ParsedArticles by their published date.
+func sortArticleDesc(a ParsedArticle, b ParsedArticle) int {
+	if a.Meta.PublishedAt.IsZero() && b.Meta.PublishedAt.IsZero() {
+		return 0
+	}
+	if a.Meta.PublishedAt.IsZero() {
+		return -1
+	}
+	if b.Meta.PublishedAt.IsZero() {
+		return 1
+	}
+
+	if a.Meta.PublishedAt.After(b.Meta.PublishedAt) {
+		return -1
+	}
+
+	return 1
 }

--- a/internal/changelog/parser.go
+++ b/internal/changelog/parser.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"sync"
 	"time"
+
+	"github.com/yuin/goldmark"
 )
 
 type Meta struct {
@@ -34,10 +36,10 @@ type ParseResult struct {
 	HasMore  bool
 }
 
-func NewParser() Parser {
+func NewParser(gm goldmark.Markdown) Parser {
 	return Parser{
-		og: newOGParser(),
-		k:  newKeepAChangelogParser(),
+		og: NewOGParser(gm),
+		k:  NewKeepAChangelogParser(gm),
 	}
 }
 

--- a/internal/changelog/parser_test.go
+++ b/internal/changelog/parser_test.go
@@ -1,0 +1,172 @@
+package changelog
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParse(t *testing.T) {
+	p := NewParser()
+	tables := []struct {
+		name                  string
+		files                 []string
+		page                  Pagination
+		expectedHasMore       bool
+		expectedArticleLength int
+	}{
+		{
+			name:                  "OG one",
+			files:                 []string{"v0.0.1-commonmark.md"},
+			page:                  NoPagination(),
+			expectedHasMore:       false,
+			expectedArticleLength: 1,
+		},
+		{
+			name:                  "OG multiple",
+			files:                 []string{"v0.0.1-commonmark.md", "v0.0.2-open-source.md", "v0.0.5-beta.md"},
+			page:                  NoPagination(),
+			expectedHasMore:       false,
+			expectedArticleLength: 3,
+		},
+		{
+			name:                  "Keepachangelog no pagination",
+			files:                 []string{"keepachangelog/minimal.md"},
+			page:                  NoPagination(),
+			expectedHasMore:       false,
+			expectedArticleLength: 1,
+		},
+		{
+			name:                  "Keepachangelog full no pagination",
+			files:                 []string{"keepachangelog/full.md"},
+			page:                  NoPagination(),
+			expectedHasMore:       false,
+			expectedArticleLength: 15,
+		},
+		{
+			name:                  "Keepachangelog full paginated",
+			files:                 []string{"keepachangelog/full.md"},
+			page:                  NewPagination(4, 2),
+			expectedHasMore:       true,
+			expectedArticleLength: 4,
+		},
+	}
+
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			articles := make([]RawArticle, 0, len(table.files))
+			for _, file := range table.files {
+				content, err := os.Open(fmt.Sprintf("../../.testdata/%s", file))
+				if err != nil {
+					t.Fatal(err)
+				}
+				articles = append(articles, RawArticle{Content: content})
+			}
+
+			parsed := p.Parse(context.Background(), articles, table.page)
+			if len(parsed.Articles) != table.expectedArticleLength {
+				t.Errorf("Expected article length %d but got %d", table.expectedArticleLength, len(parsed.Articles))
+			}
+			if parsed.HasMore != table.expectedHasMore {
+				t.Errorf("Expected hasMore %t but got %t", table.expectedHasMore, parsed.HasMore)
+			}
+		})
+	}
+}
+
+func TestSortArticleDesc(t *testing.T) {
+	tables := []struct {
+		name   string
+		a      time.Time
+		b      time.Time
+		aFirst bool
+	}{
+		{
+			name:   "a zero",
+			b:      time.Now(),
+			aFirst: true,
+		},
+		{
+			name:   "b zero",
+			a:      time.Now(),
+			aFirst: false,
+		},
+		{
+			name:   "a earlier",
+			a:      time.Date(2024, 10, 20, 0, 0, 0, 0, time.UTC),
+			b:      time.Date(2024, 10, 19, 0, 0, 0, 0, time.UTC),
+			aFirst: true,
+		},
+		{
+			name: "b earlier",
+			a:    time.Date(2024, 10, 19, 0, 0, 0, 0, time.UTC),
+			b:    time.Date(2024, 10, 20, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+
+			slice := []ParsedArticle{
+				{Meta: Meta{Title: "a", PublishedAt: table.a}},
+				{Meta: Meta{Title: "b", PublishedAt: table.b}},
+			}
+			slices.SortFunc(slice, sortArticleDesc)
+
+			aFirst := slice[0].Meta.Title == "a"
+			if aFirst != table.aFirst {
+				t.Error("Expected a to be first but got b")
+			}
+		})
+	}
+}
+
+func TestDetectFileFormat(t *testing.T) {
+	testCases := []struct {
+		name     string
+		file     string
+		expected FileFormat
+	}{
+		{
+			name:     "OG format with frontmatter",
+			file:     "---\ntitle: Test\n---",
+			expected: OG,
+		},
+		{
+			name:     "KeepAChangelog format",
+			file:     "# Changelog",
+			expected: KeepAChangelog,
+		},
+		{
+			name:     "Empty line",
+			file:     "",
+			expected: OG,
+		},
+		{
+			name:     "Line without frontmatter",
+			file:     "This is a regular line",
+			expected: KeepAChangelog,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := strings.NewReader(tc.file)
+			result, read := detectFileFormat(r)
+			if result != tc.expected {
+				t.Errorf("Expected %v, but got %v", tc.expected, result)
+			}
+
+			rest, _ := io.ReadAll(r)
+			expectedRest, _ := strings.CutPrefix(tc.file, read)
+			if string(rest) != expectedRest {
+				t.Errorf("Expected rest=%q got=%q", expectedRest, string(rest))
+			}
+		})
+	}
+}

--- a/internal/changelog/parser_test.go
+++ b/internal/changelog/parser_test.go
@@ -35,6 +35,13 @@ func TestParse(t *testing.T) {
 			expectedArticleLength: 3,
 		},
 		{
+			name:                  "OG pagination not used",
+			files:                 []string{"v0.0.1-commonmark.md", "v0.0.2-open-source.md", "v0.0.5-beta.md"},
+			page:                  NewPagination(2, 1),
+			expectedHasMore:       false,
+			expectedArticleLength: 3,
+		},
+		{
 			name:                  "Keepachangelog no pagination",
 			files:                 []string{"keepachangelog/minimal.md"},
 			page:                  NoPagination(),

--- a/internal/changelog/parser_test.go
+++ b/internal/changelog/parser_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	p := NewParser()
+	p := NewParser(createGoldmark())
 	tables := []struct {
 		name                  string
 		files                 []string

--- a/internal/changelog/source.go
+++ b/internal/changelog/source.go
@@ -14,7 +14,7 @@ type LoadResult struct {
 	HasMore  bool
 }
 
-// A source is used to download the changelog articles from a targe
+// A source is used to download the changelog articles from a target
 type Source interface {
 	Load(ctx context.Context, page Pagination) (LoadResult, error)
 }

--- a/internal/handler/rest/changelog.go
+++ b/internal/handler/rest/changelog.go
@@ -248,10 +248,7 @@ func getFullChangelog(e *env, w http.ResponseWriter, r *http.Request) error {
 		return errs.NewBadRequest(err)
 	}
 
-	parsed, err := loader.Parse(r.Context())
-	if err != nil {
-		return errs.NewBadRequest(err)
-	}
+	parsed := loader.Parse(r.Context())
 
 	articles := make([]apitypes.Article, len(parsed.Articles))
 	for i, a := range parsed.Articles {

--- a/internal/handler/rss/rss.go
+++ b/internal/handler/rss/rss.go
@@ -23,10 +23,7 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	parsed, err := l.Parse(r.Context())
-	if err != nil {
-		return err
-	}
+	parsed := l.Parse(r.Context())
 
 	if parsed.CL.Protected {
 		authorize := r.URL.Query().Get(handler.AUTHORIZE_QUERY)

--- a/internal/handler/utils.go
+++ b/internal/handler/utils.go
@@ -104,7 +104,7 @@ func GetQueryIDs(r *http.Request) (wID string, cID string) {
 // If in db-mode => load changelog by query ids or host.
 //
 // If in config mode => load changelog from config.
-func LoadChangelog(loader *changelog.Loader, isDBMode bool, r *http.Request, page changelog.Pagination) (*changelog.LoadedChangelog, error) {
+func LoadChangelog(loader *changelog.Loader, isDBMode bool, r *http.Request, page changelog.Pagination) (changelog.LoadedChangelog, error) {
 	if isDBMode {
 		return loadChangelogDBMode(loader, r, page)
 	} else {
@@ -112,7 +112,7 @@ func LoadChangelog(loader *changelog.Loader, isDBMode bool, r *http.Request, pag
 	}
 }
 
-func loadChangelogDBMode(loader *changelog.Loader, r *http.Request, page changelog.Pagination) (*changelog.LoadedChangelog, error) {
+func loadChangelogDBMode(loader *changelog.Loader, r *http.Request, page changelog.Pagination) (changelog.LoadedChangelog, error) {
 	wID, cID := GetQueryIDs(r)
 	if wID != "" && cID != "" {
 		return loader.FromWorkspace(r.Context(), wID, cID, page)

--- a/internal/handler/web/index.go
+++ b/internal/handler/web/index.go
@@ -18,10 +18,7 @@ func index(e *env, w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	parsed, err := l.Parse(r.Context())
-	if err != nil {
-		return err
-	}
+	parsed := l.Parse(r.Context())
 
 	if parsed.CL.Protected {
 		err = ensurePasswordProvided(r, parsed.CL.PasswordHash)

--- a/internal/handler/web/password.go
+++ b/internal/handler/web/password.go
@@ -35,10 +35,7 @@ func passwordSubmit(e *env, w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	parsed, err := l.Parse(r.Context())
-	if err != nil {
-		return err
-	}
+	parsed := l.Parse(r.Context())
 
 	err = handler.ValidatePassword(parsed.CL.PasswordHash, pw)
 	if err != nil {


### PR DESCRIPTION
Fix wrong parsing caused by keep-a-changelog parser being used if only one release-node file is loaded.
We now only use the keep-a-changelog parser if one release-node file is loaded **and** the file doesn't start with `---` (frontmatter)