### PR TITLE
Prevent post title from being hidden when page loads

### DIFF
--- a/internal/handler/web/css/base.css
+++ b/internal/handler/web/css/base.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    scroll-padding-top: 64px;
+    scroll-behavior: smooth;
+}
+
 @layer components {
     .input {
         @apply o-text-sm o-py-2 o-px-3 o-rounded-md o-border dark:o-border-white/10 dark:focus-within:o-border-white/20


### PR DESCRIPTION
When a user visits a link with a post ID, the navbar appears above the title:

![image](https://github.com/user-attachments/assets/fe6db8fd-cddd-4621-ade7-023f380dc565)

Using the scroll-padding property makes the title visible as soon as the page loads.
