### PR TITLE
Fix container crash because of favicon.ico request

### DIFF
--- a/components/article.templ
+++ b/components/article.templ
@@ -28,7 +28,7 @@ type ArticleArgs struct {
 templ Article(a ArticleArgs) {
 	<article class="o-relative">
 		<h2 id={ a.ID } class="o-group">
-			<a class="o-not-prose" href={ templ.URL(fmt.Sprintf("/%s", a.ID)) }>{ a.Title }</a>
+			<a class="o-not-prose" href={ templ.URL(fmt.Sprintf("/release/%s", a.ID)) }>{ a.Title }</a>
 			<a
 				class="o-opacity-0 group-hover:o-opacity-100 o-transition-opacity"
 				href={ templ.URL(fmt.Sprintf("#%s", a.ID)) }

--- a/components/article_templ.go
+++ b/components/article_templ.go
@@ -90,7 +90,7 @@ func Article(a ArticleArgs) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var4 templ.SafeURL = templ.URL(fmt.Sprintf("/%s", a.ID))
+		var templ_7745c5c3_Var4 templ.SafeURL = templ.URL(fmt.Sprintf("/release/%s", a.ID))
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var4)))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -102,7 +102,7 @@ func Article(a ArticleArgs) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(a.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 31, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/article.templ`, Line: 31, Col: 88}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {

--- a/components/search.templ
+++ b/components/search.templ
@@ -30,7 +30,7 @@ templ SearchResults(args SearchResultsArgs) {
 
 templ SearchResult(h search.SearchResult) {
 	<a
-		href={ templ.URL(fmt.Sprintf("/%s", h.ID)) }
+		href={ templ.URL(fmt.Sprintf("/release/%s", h.ID)) }
 		class="o-group o-flex o-items-center o-px-4 o-py-2 o-rounded-lg hover:o-bg-primary/5"
 	>
 		<div class="o-flex-1">

--- a/components/search_templ.go
+++ b/components/search_templ.go
@@ -95,7 +95,7 @@ func SearchResult(h search.SearchResult) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 templ.SafeURL = templ.URL(fmt.Sprintf("/%s", h.ID))
+		var templ_7745c5c3_Var3 templ.SafeURL = templ.URL(fmt.Sprintf("/release/%s", h.ID))
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var3)))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -231,7 +231,7 @@ func emptySearchResults(query string) templ.Component {
 
 type SearchButtonArgs struct {
 	HasMetaKey bool
-	Active     bool // whether the click should actually open the search modal
+	Active     bool // whether the click should open the search modal
 }
 
 func SearchButton(args SearchButtonArgs) templ.Component {

--- a/internal/handler/web/routes.go
+++ b/internal/handler/web/routes.go
@@ -21,7 +21,7 @@ import (
 
 func RegisterWebHandler(mux *http.ServeMux, e *env) {
 	mux.HandleFunc("GET /", serveHTTP(e, index))
-	mux.HandleFunc("GET /{nid}", serveHTTP(e, details))
+	mux.HandleFunc("GET /release/{nid}", serveHTTP(e, details))
 	mux.HandleFunc("POST /password", serveHTTP(e, passwordSubmit))
 	mux.HandleFunc("POST /search", serveHTTP(e, searchSubmit))
 	mux.HandleFunc("GET /search/tags", serveHTTP(e, searchTags))

--- a/internal/parse/og.go
+++ b/internal/parse/og.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"log/slog"
 
+	"github.com/jonashiltl/openchangelog/internal/xlog"
 	enclave "github.com/quail-ink/goldmark-enclave"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
@@ -78,6 +80,7 @@ func (g *ogparser) parseReleaseNoteBytes(content []byte) (ParsedReleaseNote, err
 	var target bytes.Buffer
 	err := g.gm.Convert(content, &target, gmparser.WithContext(ctx))
 	if err != nil {
+		slog.Warn("failed to convert to html", xlog.ErrAttr(err))
 		return ParsedReleaseNote{}, err
 	}
 
@@ -90,6 +93,7 @@ func (g *ogparser) parseReleaseNoteBytes(content []byte) (ParsedReleaseNote, err
 	var meta Meta
 	err = data.Decode(&meta)
 	if err != nil {
+		slog.Warn("failed to parse frontmatter", xlog.ErrAttr(err))
 		return ParsedReleaseNote{}, err
 	}
 


### PR DESCRIPTION
Moves the details route from `/{note-id}` to `/release/{note-id}` so that it doesn't clash with favicon requests