### PR TITLE
fix: format pubDate according to the RSS specification

### DIFF
--- a/internal/handler/rss/feed.tmpl
+++ b/internal/handler/rss/feed.tmpl
@@ -5,7 +5,7 @@
     <title>{{.CL.Title.V}}</title>
     <description>{{.CL.Subtitle.V}}</description>
     <link>{{ .Link }}</link>
-    <pubDate>{{ toRFC822 .CL.CreatedAt }}</pubDate>
+    <pubDate>{{ toPubDate .CL.CreatedAt }}</pubDate>
 
     {{range .Articles}}
     <item>
@@ -21,7 +21,7 @@
           {{.Content}}
         ]]>
         </description>
-      <pubDate>{{ toRFC822 .Meta.PublishedAt }}</pubDate>
+      <pubDate>{{ toPubDate .Meta.PublishedAt }}</pubDate>
     </item>
     {{end}}
   </channel>

--- a/internal/handler/rss/rss.go
+++ b/internal/handler/rss/rss.go
@@ -39,7 +39,7 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 		New("feed").
 		Funcs(template.FuncMap{
 			"addFragment": addFragment,
-			"toRFC822":    toRFC822,
+			"toPubDate":    toPubDate,
 		}).
 		Parse(feedTemplate)
 	if err != nil {
@@ -57,8 +57,10 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 	return tmpl.Execute(w, args)
 }
 
-func toRFC822(t time.Time) string {
-	return t.Format(time.RFC822)
+func toPubDate(t time.Time) string {
+    // time.RFC822 produces an different format than the expected format for RSS. Day of the week is missing.
+    // time.RFC822 and time.RFC1123 may produce "UTC" as timezone but the spec only allows "GMT", "UT", "Z", or "0000".
+	return strings.ReplaceAll(t.Format(time.RFC1123), "UTC", "GMT")
 }
 
 // Adds a fragment to the specified url

--- a/internal/handler/rss/rss_test.go
+++ b/internal/handler/rss/rss_test.go
@@ -1,0 +1,49 @@
+package rss
+
+import (
+	"testing"
+	"time"
+)
+
+func TestToPubDate(t *testing.T) {
+	// Define a fixed location for consistency if needed, 
+	// though toPubDate handles UTC to GMT conversion.
+	utc := time.UTC
+
+	testCases := []struct {
+		name     string
+		input    time.Time
+		expected string
+	}{
+		{
+			name:     "Standard UTC date",
+			input:    time.Date(2026, time.March, 20, 16, 24, 0, 0, utc),
+			expected: "Fri, 20 Mar 2026 16:24:00 GMT",
+		},
+		{
+			name:     "Leap year date",
+			input:    time.Date(2024, time.February, 29, 0, 0, 0, 0, utc),
+			expected: "Thu, 29 Feb 2024 00:00:00 GMT",
+		},
+		{
+			name:     "Zero value date",
+			input:    time.Time{},
+			expected: "Mon, 01 Jan 0001 00:00:00 GMT",
+		},
+		{
+			name:     "Ensure UTC is replaced by GMT",
+			// time.RFC1123 outputs "UTC" for UTC location
+			input:    time.Date(2023, time.October, 27, 10, 0, 0, 0, utc),
+			expected: "Fri, 27 Oct 2023 10:00:00 GMT",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := toPubDate(tc.input)
+			if result != tc.expected {
+				t.Errorf("toPubDate() = %q, expected %q", result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The RSS feed contains dates in `pubDate` in a format that fails to pass [feed validation](https://validator.w3.org/feed/).

[RSS feeds](https://www.rssboard.org/rss-specification#optionalChannelElements) expect dates to comply to [RFC-822 Section 5](https://www.rfc-editor.org/rfc/rfc822.html#section-5).

Golang's `time.RFC822` is used to format the `pubDate`, but that produces a different format:

1. Day of the week is missing
2. Timezone is "UTC", which is not one of the expected strings in RFC822. Allowed are "GMT", "UT", "Z", or "0000".  

## Changes

1. Switched to `time.RFC1123` to produce a date string in a format closer to the expected format.
2. Use strings.ReplaceAll to change "UTC" into "GMT" 
3. Renamed the function from `toRFC822` to `toPubDate` to reflect its specific purpose

## Related
<!-- Issues: "Fixes #123", "Closes #123", "Related to #123" -->

## Checklist
- [X] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [ ] I have updated documentation where necessary
- [x] Existing tests pass
- [x] Added tests for new functionality (if applicable)
- [X] Manually verified changes work as expected
- [ ] I have considered the impact on existing functionality