### PR TITLE
use latest release publish date for channel pubDate

### DIFF
--- a/internal/handler/rss/feed.tmpl
+++ b/internal/handler/rss/feed.tmpl
@@ -5,7 +5,7 @@
     <title>{{.CL.Title.V}}</title>
     <description>{{.CL.Subtitle.V}}</description>
     <link>{{ .Link }}</link>
-    <pubDate>{{ toPubDate .CL.CreatedAt }}</pubDate>
+    <pubDate>{{ toPubDate .CreatedAt }}</pubDate>
 
     {{range .Articles}}
     <item>

--- a/internal/handler/rss/rss.go
+++ b/internal/handler/rss/rss.go
@@ -35,11 +35,16 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
+	createdAt := loaded.CL.CreatedAt
+	if createdAt.IsZero() && len(loaded.Notes) > 0 {
+		createdAt = loaded.Notes[0].Meta.PublishedAt
+	}
+
 	tmpl, err := template.
 		New("feed").
 		Funcs(template.FuncMap{
 			"addFragment": addFragment,
-			"toPubDate":    toPubDate,
+			"toPubDate":   toPubDate,
 		}).
 		Parse(feedTemplate)
 	if err != nil {
@@ -49,17 +54,18 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 	w.Header().Set("Content-Type", "application/rss+xml")
 	link := handler.FeedToChangelogURL(r)
 	args := map[string]any{
-		"CL":       loaded.CL,
-		"Articles": loaded.Notes,
-		"HasMore":  loaded.HasMore,
-		"Link":     strings.ReplaceAll(link, "&", "&amp;"), // & is reserved in xml
+		"CL":        loaded.CL,
+		"Articles":  loaded.Notes,
+		"HasMore":   loaded.HasMore,
+		"CreatedAt": createdAt,
+		"Link":      strings.ReplaceAll(link, "&", "&amp;"), // & is reserved in xml
 	}
 	return tmpl.Execute(w, args)
 }
 
 func toPubDate(t time.Time) string {
-    // time.RFC822 produces an different format than the expected format for RSS. Day of the week is missing.
-    // time.RFC822 and time.RFC1123 may produce "UTC" as timezone but the spec only allows "GMT", "UT", "Z", or "0000".
+	// time.RFC822 produces an different format than the expected format for RSS. Day of the week is missing.
+	// time.RFC822 and time.RFC1123 may produce "UTC" as timezone but the spec only allows "GMT", "UT", "Z", or "0000".
 	return strings.ReplaceAll(t.Format(time.RFC1123), "UTC", "GMT")
 }
 

--- a/internal/handler/rss/rss.go
+++ b/internal/handler/rss/rss.go
@@ -35,11 +35,6 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	createdAt := loaded.CL.CreatedAt
-	if createdAt.IsZero() && len(loaded.Notes) > 0 {
-		createdAt = loaded.Notes[0].Meta.PublishedAt
-	}
-
 	tmpl, err := template.
 		New("feed").
 		Funcs(template.FuncMap{
@@ -52,7 +47,13 @@ func feedHandler(e *env, w http.ResponseWriter, r *http.Request) error {
 	}
 
 	w.Header().Set("Content-Type", "application/rss+xml")
+
 	link := handler.FeedToChangelogURL(r)
+	createdAt := loaded.CL.CreatedAt
+	if createdAt.IsZero() && len(loaded.Notes) > 0 {
+		createdAt = loaded.Notes[0].Meta.PublishedAt
+	}
+
 	args := map[string]any{
 		"CL":        loaded.CL,
 		"Articles":  loaded.Notes,


### PR DESCRIPTION
## Summary
When in config mode the `pubDate` of the RSS channel is always go zero time value.

## Changes
Use the publish date of the latest release note instead.

## Related
Fixes #53 

## Checklist
- [x] I have read and followed the [contributing guidelines](CONTRIBUTING.md)
- [x] I have updated documentation where necessary
- [x] Existing tests pass
- [ ] Added tests for new functionality (if applicable)
- [x] Manually verified changes work as expected
- [x] I have considered the impact on existing functionality