### PR TITLE
fix: hide changelog entries until their publishedAt date arrives

### DIFF
--- a/internal/load/loader.go
+++ b/internal/load/loader.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"time"
 
 	mint "github.com/btvoidx/mint/context"
 	"github.com/jonashiltl/openchangelog/internal"
@@ -65,13 +66,33 @@ func (l *Loader) GetChangelog(r *http.Request) (store.Changelog, error) {
 }
 
 // Loads the changelog and parses it's release notes for the specified http request.
+// Release notes scheduled to be published in the future are excluded from the result.
 func (l *Loader) LoadAndParse(r *http.Request, page internal.Pagination) (LoadedChangelog, error) {
 	cl, err := l.GetChangelog(r)
 	if err != nil {
 		return LoadedChangelog{}, err
 	}
 
-	return l.LoadAndParseReleaseNotes(r.Context(), cl, page)
+	loaded, err := l.LoadAndParseReleaseNotes(r.Context(), cl, page)
+	if err != nil {
+		return LoadedChangelog{}, err
+	}
+
+	loaded.Notes = removeUnpublished(loaded.Notes)
+	return loaded, nil
+}
+
+// Filters out release notes with a publishedAt date in the future,
+// so they stay hidden until that date/time arrives.
+func removeUnpublished(notes []parse.ParsedReleaseNote) []parse.ParsedReleaseNote {
+	now := time.Now()
+	published := notes[:0]
+	for _, n := range notes {
+		if !n.Meta.PublishedAt.After(now) {
+			published = append(published, n)
+		}
+	}
+	return published
 }
 
 // Loads and parses the release notes for the specified changelog.

--- a/internal/load/loader_test.go
+++ b/internal/load/loader_test.go
@@ -1,0 +1,55 @@
+package load
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonashiltl/openchangelog/internal/parse"
+)
+
+func TestRemoveUnpublished(t *testing.T) {
+	now := time.Now()
+
+	tables := []struct {
+		name     string
+		notes    []parse.ParsedReleaseNote
+		expected []string
+	}{
+		{
+			name: "keeps past and zero-value publishedAt, drops future",
+			notes: []parse.ParsedReleaseNote{
+				{Meta: parse.Meta{ID: "past", PublishedAt: now.Add(-time.Hour)}},
+				{Meta: parse.Meta{ID: "future", PublishedAt: now.Add(time.Hour)}},
+				{Meta: parse.Meta{ID: "no-date", PublishedAt: time.Time{}}},
+			},
+			expected: []string{"past", "no-date"},
+		},
+		{
+			name:     "empty input",
+			notes:    []parse.ParsedReleaseNote{},
+			expected: []string{},
+		},
+		{
+			name: "all future",
+			notes: []parse.ParsedReleaseNote{
+				{Meta: parse.Meta{ID: "future1", PublishedAt: now.Add(time.Hour)}},
+				{Meta: parse.Meta{ID: "future2", PublishedAt: now.Add(24 * time.Hour)}},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, table := range tables {
+		t.Run(table.name, func(t *testing.T) {
+			got := removeUnpublished(table.notes)
+			if len(got) != len(table.expected) {
+				t.Fatalf("expected %d notes but got %d", len(table.expected), len(got))
+			}
+			for i, n := range got {
+				if n.Meta.ID != table.expected[i] {
+					t.Errorf("expected note at index %d to be %q but got %q", i, table.expected[i], n.Meta.ID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Currently, a release note with a `publishedAt` date in the future is displayed immediately, so scheduled/staged rollouts aren't possible (closes the reported issue).
- `Loader.LoadAndParse` now filters out release notes whose `publishedAt` is after the current time. This method backs all public-facing routes: the changelog page, widget, article detail page, RSS feed, and password-protected view.
- Entries without a `publishedAt` (zero value) or with a past date are unaffected.
- The admin REST API (`GET /api/changelogs/{cid}/full`, used to manage a changelog) intentionally still returns scheduled entries, so changelog owners can see and edit posts staged for the future.

## Test plan
- [x] Added `internal/load/loader_test.go` covering past/future/zero-date/all-future filtering
- [x] `go build ./...`
- [x] `go test ./...` passes (pre-existing, unrelated failures in `TestKParseUnreleased`/`TestKParsePagination` on `main` are untouched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)